### PR TITLE
Handle case when experiment_dir is not provided

### DIFF
--- a/mle_scheduler/job.py
+++ b/mle_scheduler/job.py
@@ -376,8 +376,9 @@ class MLEJob(object):
 
     def generate_cmd_line_args(self) -> str:
         """Generate cmd line args for .py -> get_train_configs_ready"""
+        cmd_line_args = ""
         if self.experiment_dir is not None:
-            cmd_line_args = " -exp_dir " + self.experiment_dir
+            cmd_line_args += " -exp_dir " + self.experiment_dir
 
         if self.config_filename is not None:
             cmd_line_args += " -config " + self.config_filename


### PR DESCRIPTION
At the moment if "experiment_dir" is None, then cmd_line_args is not initialized, and hence future lines like cmd_line_args += " -config " + self.config_filename will fail.

The proposed change just initializes cmd_line_args to the empty string, and then adds all options to it later.